### PR TITLE
Fix artist name in the colophon

### DIFF
--- a/src/epub/text/colophon.xhtml
+++ b/src/epub/text/colophon.xhtml
@@ -29,7 +29,7 @@
 			<p>The cover page is adapted from<br/>
 			<i epub:type="se:name.visual-art.painting">Le Déjeuner sur l’herbe</i>,<br/>
 			a painting completed in 1863 by<br/>
-			<a href="https://en.wikipedia.org/wiki/%C3%89douard_Manet">Paul Cézanne</a>.<br/>
+			<a href="https://en.wikipedia.org/wiki/%C3%89douard_Manet">Édouard Manet</a>.<br/>
 			The cover and title pages feature the<br/>
 			<span epub:type="se:name.visual-art.typeface">League Spartan</span> and <span epub:type="se:name.visual-art.typeface">Sorts Mill Goudy</span><br/>
 			typefaces created in 2014 and 2009 by<br/>


### PR DESCRIPTION
Looks like this single place was missed when [the original artwork was changed](https://github.com/standardebooks/emile-zola_his-masterpiece_ernest-alfred-vizetelly/commit/8465855099274bb5fafaa0a595737a2ccd59194c).